### PR TITLE
changed number of approvers from 2 to 1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Contributions to our repos are welcomed by any user interested in the improvemen
     - Please reference any associated issues ensuring they are closed when Pull Request is closed
       - [Pull Request Template](https://github.com/jsimoni-org/terraform-module-template/.github/pull_request_template.md)
       - [Closing Issues using Keywords](https://help.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords#about-issue-references)
-7. Request 2 Approvers.  1 of which must be a code owner
+7. Request at least 1 approver (GitHub will automatically populate the approvers with code owners as approval from a code owners is required to merge).
 8. Pull Request will be merged if approved, and if all GH actions completed successfully
 
 ## Code of Conduct


### PR DESCRIPTION
# Description

GitHub does not allow PR authors to approve PR requests so there is no concern about someone approving their own PR request.

Fixes # n/a

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] My code follows the [style guidelines for Terraform](https://www.terraform.io/docs/configuration/style.html) ([terraform fmt](https://www.terraform.io/docs/commands/fmt.html) will enforce this at PR)
- [x] I have performed a self-review of my own code
- [x] I have [commented](https://www.terraform.io/docs/configuration/syntax.html#comments) my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes (PRs run a number of tests such as [terraform init](https://www.terraform.io/docs/commands/init.html), [terraform validate](https://www.terraform.io/docs/commands/validate.html), and [checkov](https://www.checkov.io/))
- [x] Any dependent changes have been merged and published in downstream modules
